### PR TITLE
Fix missing keys error on Column layout, unwanted semicolon on html block & local install with yarn

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+yarn.lock
+package-lock.json
+*.log
+node_modules/

--- a/src/blocks/format/html.tsx
+++ b/src/blocks/format/html.tsx
@@ -6,7 +6,7 @@ class WPGHtmlBlock extends React.Component<IWPGBlock> {
 
   componentDidMount() {
     document.querySelectorAll(`[data-script="${this.id}"]`).forEach((script) => {
-      ;(window as any).eval(script.innerHTML)
+      window.eval(script.innerHTML)
     })
   }
 

--- a/src/blocks/layout/columns.tsx
+++ b/src/blocks/layout/columns.tsx
@@ -17,7 +17,7 @@ const WPGColumnsBlock: React.FC<IWPGBlock> = (props) => {
   const cols = innerBlocks.length
 
   const columns = innerBlocks.map((col, ci) => (
-    <div className={`wp-block-column ${ci + 1}-column`}>
+    <div className={`wp-block-column ${ci + 1}-column`} key={ci}>
       {col.innerBlocks.map((block, bi) => (
         <WPGBlock key={bi} block={block} />
       ))}


### PR DESCRIPTION

  Squashed commit of the following:

    Fix unwanted semicolon
    - casting window to any to use eval is no longer needed as ts now supports globalThis

    Add NPMIGNORE so yarn doesn't delete dist folder on "local" install (aka via git)

    Fix for Missing Key Error on Columns